### PR TITLE
Disable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       directory: "/" # Location of package manifests
       schedule:
           interval: "monthly"
+      # Turn off dependabot until we have a clear upgrade path to ESLint 9
+      # See https://phabricator.wikimedia.org/T387567
+      open-pull-requests-limit: 0
       groups:
           minor-version-updates:
               update-types:


### PR DESCRIPTION
We don't have production dependencies, only dev dependencies for running a
web server and doing linting. The update to ESLint 9 is a significant
change and until we have done this, we don't want to litter this repo
with failing pull requests for ESLint or its plugins.

Ticket: https://phabricator.wikimedia.org/T387567
