### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7417,9 +7417,9 @@
 			}
 		},
 		"node_modules/qs": {
-			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-			"integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+			"version": "6.14.1",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.1.tgz",
+			"integrity": "sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {


### PR DESCRIPTION
`qs` (a query string parsing library) was showing up in the weekly GitHub dependabot vulnerability report. Not a big issue since it's a transitive dependency of our dev dependencies.

Ran `npm audit fix` to fix it